### PR TITLE
Fix macos issue

### DIFF
--- a/pypemicro/pemicro.py
+++ b/pypemicro/pemicro.py
@@ -541,6 +541,7 @@ class PyPemicro:
         # Initialize the basic objects
         self._opened = False
         self.dll_path = dll_path
+        self.lib = None
         self.lib = PyPemicro.get_pemicro_lib(dll_path)
 
         self.interface = PEMicroInterfaces.SWD

--- a/pypemicro/pemicro.py
+++ b/pypemicro/pemicro.py
@@ -386,6 +386,20 @@ class PyPemicro:
         dll.set_mcu_register.argtypes = [c_ulong, c_ulong, c_ulong]
         dll.set_mcu_register.restype = c_bool
 
+        if (
+            dll.pe_special_features(
+                PEMicroSpecialFeatures.PE_SET_DEFAULT_APPLICATION_FILES_DIRECTORY,
+                True,
+                0,
+                0,
+                0,
+                c_char_p(os.path.dirname(os.path.abspath(file_name).encode("utf-8"))),
+                None,
+            )
+            is False
+        ):
+            raise PEMicroException("The special feature command hasn't been accepted")
+
         logger.debug(f"Opened PEMicro library: {file_name}, {dll.version()}.")
 
         return dll


### PR DESCRIPTION
The pypemicro probe is not detected on macOS. I have identified that this piece of code, which was part of the previous release of pypemicro, is the reason why it's not detected. 